### PR TITLE
Use new discovery scan service

### DIFF
--- a/bootstrap/playbooks/pxe.yaml
+++ b/bootstrap/playbooks/pxe.yaml
@@ -54,6 +54,7 @@
     # Install discovery service
     - shell: pip install git+https://github.com/rustyrobot/discovery.git
     - shell: 'discovery &'
+    - shell: 'discovery-scan --ssh_key {{insecure_pub_key_path}} &'
 
     # Install bareon-api
     - shell: pip install git+https://github.com/Mirantis/bareon-api.git


### PR DESCRIPTION
Instead of pulling data about nodes into the discovery
when provisioning starts, use a separate service that
will periodically scan nodes.
